### PR TITLE
Use Maven plugin annotations, and mark mojo as threadsafe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,28 @@
 	</executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>3.2</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+        <executions>
+          <execution>
+            <id>mojo-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>help-goal</id>
+            <goals>
+              <goal>helpmojo</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
 	<groupId>org.apache.maven.plugins</groupId>
 	<artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
@@ -84,6 +106,12 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.0.9</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.maven.plugin-tools</groupId>
+        <artifactId>maven-plugin-annotations</artifactId>
+        <version>3.3</version>
+        <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/main/java/org/scalariform/ScalariformMojo.java
+++ b/src/main/java/org/scalariform/ScalariformMojo.java
@@ -2,135 +2,92 @@ package org.scalariform;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Goal which formats scala source files
- *
- * @goal format
- * 
- * @phase process-sources
  */
+@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class ScalariformMojo extends AbstractMojo {
 
     /**
      * Base directory of the project
-     *
-     * @parameter expression="${basedir}"
-     * @required
      */
+    @Parameter(property = "basedir", required = true)
     protected String baseDir;
 
     /**
      * Source file encoding, e.g. UTF-8. If not set, defaults to the platform default encoding.
-     *
-     * @parameter expression="${encoding}" default-value="${project.build.sourceEncoding}"
      */
+    @Parameter(property = "encoding", defaultValue = "${project.build.sourceEncoding}")
     protected String encoding;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean alignParameters;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean alignSingleLineCaseStatements;
 
-    /**
-     *  @parameter default-value=40
-     */
+    @Parameter(defaultValue = "40")
     protected int alignSingleLineCaseStatements_maxArrowIndent;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean compactControlReadability;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean compactStringConcatenation;
 
-    /**
-     *  @parameter default-value=true
-     */
+    @Parameter(defaultValue = "true")
     protected boolean doubleIndentClassDeclaration;
 
-    /**
-     *  @parameter default-value=true
-     */
+    @Parameter(defaultValue = "true")
     protected boolean formatXml;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean indentLocalDefs;
 
-    /**
-     *  @parameter default-value=true
-     */
+    @Parameter(defaultValue = "true")
     protected boolean indentPackageBlocks;
 
-    /**
-     *  @parameter default-value=2
-     */
+    @Parameter(defaultValue = "2")
     protected int indentSpaces;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean indentWithTabs;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean multilineScaladocCommentsStartOnFirstLine;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean placeScaladocAsterisksBeneathSecondAsterisk;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean preserveDanglingCloseParenthesis;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean preserveSpaceBeforeArguments;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean rewriteArrowSymbols;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean spaceBeforeColon;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean spaceInsideBrackets;
 
-    /**
-     *  @parameter default-value=false
-     */
+    @Parameter(defaultValue = "false")
     protected boolean spaceInsideParentheses;
-    
-    /**
-     *  @parameter default-value=true
-     */
+
+    @Parameter(defaultValue = "true")
     protected boolean spacesWithinPatternBinders;
 
     public void execute() throws MojoExecutionException {
 
 	MojoFormatter.format(baseDir, encoding, this.getLog(),
-                             alignParameters, 
+                             alignParameters,
                              alignSingleLineCaseStatements,
                              alignSingleLineCaseStatements_maxArrowIndent,
                              compactControlReadability,
@@ -151,6 +108,4 @@ public class ScalariformMojo extends AbstractMojo {
                              spaceInsideParentheses,
                              spacesWithinPatternBinders);
     }
-
 }
-

--- a/src/main/java/org/scalariform/ScalariformMojo.java
+++ b/src/main/java/org/scalariform/ScalariformMojo.java
@@ -21,6 +21,13 @@ public class ScalariformMojo extends AbstractMojo {
     protected String baseDir;
 
     /**
+     * Source file encoding, e.g. UTF-8. If not set, defaults to the platform default encoding.
+     *
+     * @parameter expression="${encoding}" default-value="${project.build.sourceEncoding}"
+     */
+    protected String encoding;
+
+    /**
      *  @parameter default-value=false
      */
     protected boolean alignParameters;
@@ -122,7 +129,7 @@ public class ScalariformMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException {
 
-	MojoFormatter.format(baseDir, this.getLog(),
+	MojoFormatter.format(baseDir, encoding, this.getLog(),
                              alignParameters, 
                              alignSingleLineCaseStatements,
                              alignSingleLineCaseStatements_maxArrowIndent,

--- a/src/main/java/org/scalariform/ScalariformMojo.java
+++ b/src/main/java/org/scalariform/ScalariformMojo.java
@@ -9,7 +9,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 /**
  * Goal which formats scala source files
  */
-@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
+@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true)
 public class ScalariformMojo extends AbstractMojo {
 
     /**


### PR DESCRIPTION
These changes move from Javadoc-style to Maven plugin annotations, and also mark the mojo as threadsafe to prevent warnings in parallel Maven builds.

These commits also include the change to add an 'encoding' parameter to avoid merge conflicts.
