### PR TITLE
Upgrade to scalariform:0.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.scalariform</groupId>
   <artifactId>scalariform-maven-plugin</artifactId>
-  <version>0.1.5-SNAPSHOT</version>
+  <version>0.1.8-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>Maven Scalariform Plugin</name>
   <description>Maven plugin to run Scalariform, a Scala code formatter</description>
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.scalariform</groupId>
       <artifactId>scalariform_2.10</artifactId>
-      <version>0.1.4</version>
+      <version>0.1.8</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/main/java/org/scalariform/ScalariformMojo.java
+++ b/src/main/java/org/scalariform/ScalariformMojo.java
@@ -23,6 +23,11 @@ public class ScalariformMojo extends AbstractMojo {
     /**
      *  @parameter default-value=false
      */
+    protected boolean alignArguments;
+
+    /**
+     *  @parameter default-value=false
+     */
     protected boolean alignParameters;
 
     /**
@@ -44,6 +49,11 @@ public class ScalariformMojo extends AbstractMojo {
      *  @parameter default-value=false
      */
     protected boolean compactStringConcatenation;
+
+    /**
+     *  @parameter default-value=force
+     */
+    protected String danglingCloseParenthesis;
 
     /**
      *  @parameter default-value=true
@@ -116,6 +126,11 @@ public class ScalariformMojo extends AbstractMojo {
     protected boolean spaceInsideParentheses;
     
     /**
+     *  @parameter default-value=false
+     */
+    protected boolean spacesAroundMultiImports;
+
+    /**
      *  @parameter default-value=true
      */
     protected boolean spacesWithinPatternBinders;
@@ -123,11 +138,13 @@ public class ScalariformMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
 
 	MojoFormatter.format(baseDir, this.getLog(),
+                             alignArguments,
                              alignParameters, 
                              alignSingleLineCaseStatements,
                              alignSingleLineCaseStatements_maxArrowIndent,
                              compactControlReadability,
                              compactStringConcatenation,
+                             danglingCloseParenthesis,
                              doubleIndentClassDeclaration,
                              formatXml,
                              indentLocalDefs,
@@ -142,6 +159,7 @@ public class ScalariformMojo extends AbstractMojo {
                              spaceBeforeColon,
                              spaceInsideBrackets,
                              spaceInsideParentheses,
+                             spacesAroundMultiImports,
                              spacesWithinPatternBinders);
     }
 

--- a/src/main/scala/org/scalariform/MojoFormatter.scala
+++ b/src/main/scala/org/scalariform/MojoFormatter.scala
@@ -42,11 +42,13 @@ object MojoFormatter {
 
   def format(path: String,
              log: Log,
+             alignArguments: Boolean,
              alignParameters: Boolean,
              alignSingleLineCaseStatements: Boolean,
              alignSingleLineCaseStatements_maxArrowIndent: Int,
              compactControlReadability: Boolean,
              compactStringConcatenation: Boolean,
+             danglingCloseParenthesis: String,
              doubleIndentClassDeclaration: Boolean,
              formatXml: Boolean,
              indentLocalDefs: Boolean,
@@ -61,14 +63,25 @@ object MojoFormatter {
              spaceBeforeColon: Boolean,
              spaceInsideBrackets: Boolean,
              spaceInsideParentheses: Boolean,
+             spacesAroundMultiImports: Boolean,
              spacesWithinPatternBinders: Boolean) {
 
+    def intent(value: String, pref: PreferenceDescriptor[Intent]): Intent =
+      IntentPreference.parseValue(value).fold(
+        l => {
+          log.warn(s"Could not parse ${pref.key}: $value")
+          pref.defaultValue
+        },
+        r => r)
+
     val preferences = FormattingPreferences()
+      .setPreference(AlignArguments, alignArguments)
       .setPreference(AlignParameters, alignParameters)
       .setPreference(AlignSingleLineCaseStatements, alignSingleLineCaseStatements)
       .setPreference(AlignSingleLineCaseStatements.MaxArrowIndent, alignSingleLineCaseStatements_maxArrowIndent)
       .setPreference(CompactControlReadability, compactControlReadability)
       .setPreference(CompactStringConcatenation, compactStringConcatenation)
+      .setPreference(DanglingCloseParenthesis, intent(danglingCloseParenthesis, DanglingCloseParenthesis))
       .setPreference(DoubleIndentClassDeclaration, doubleIndentClassDeclaration)
       .setPreference(FormatXml, formatXml)
       .setPreference(IndentLocalDefs, indentLocalDefs)
@@ -83,6 +96,7 @@ object MojoFormatter {
       .setPreference(SpaceBeforeColon, spaceBeforeColon)
       .setPreference(SpaceInsideParentheses, spaceInsideParentheses)
       .setPreference(SpaceInsideBrackets, spaceInsideBrackets)
+      .setPreference(SpacesAroundMultiImports, spacesAroundMultiImports)
       .setPreference(SpacesWithinPatternBinders, spacesWithinPatternBinders)
 
     val files = findScalaFiles(path)


### PR DESCRIPTION
I upgraded to scalariform 0.1.8 (now hosted by scala-ide) and added support for the new options.

Has this project been abandoned?
